### PR TITLE
Make kill_process async to avoid blocking the runtime

### DIFF
--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -168,8 +168,48 @@ pub fn kill_process_on_port(port: u16) {
     }
 }
 
-/// Kill a process by PID (graceful then force)
-pub fn kill_process(pid: u32) {
+/// Kill a process by PID (graceful then force) — async version.
+///
+/// Uses `tokio::time::sleep` instead of `std::thread::sleep` so it does not
+/// block the async runtime while waiting for the process to exit.
+pub async fn kill_process(pid: u32) {
+    #[cfg(unix)]
+    {
+        use std::process::Command;
+        let _ = Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .output();
+        for _ in 0..50 {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            if let Ok(output) = Command::new("kill").args(["-0", &pid.to_string()]).output() {
+                if !output.status.success() {
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
+        eprintln!(
+            "Process {} did not exit after SIGTERM, sending SIGKILL",
+            pid
+        );
+        let _ = Command::new("kill")
+            .args(["-KILL", &pid.to_string()])
+            .output();
+    }
+
+    #[cfg(windows)]
+    {
+        use std::process::Command;
+        let _ = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/F"])
+            .output();
+    }
+}
+
+/// Kill a process by PID — synchronous version for non-async contexts
+/// (e.g. the Tauri `RunEvent::Exit` handler).
+pub fn kill_process_sync(pid: u32) {
     #[cfg(unix)]
     {
         use std::process::Command;

--- a/src-tauri/src/services/headless.rs
+++ b/src-tauri/src/services/headless.rs
@@ -104,7 +104,7 @@ pub async fn stop_headless_internal(state: &SharedState) -> Result<String, Strin
     }
 
     if let Some(pid) = state_guard.headless_child_id {
-        kill_process(pid);
+        kill_process(pid).await;
     }
 
     state_guard.headless_running = false;

--- a/src-tauri/src/services/miner.rs
+++ b/src-tauri/src/services/miner.rs
@@ -88,7 +88,7 @@ pub async fn stop_miner_internal(state: &SharedState) -> Result<String, String> 
     }
 
     if let Some(pid) = state_guard.miner_child_id {
-        kill_process(pid);
+        kill_process(pid).await;
     }
 
     state_guard.miner_running = false;

--- a/src-tauri/src/services/node.rs
+++ b/src-tauri/src/services/node.rs
@@ -100,19 +100,19 @@ pub async fn stop_node_internal(state: &SharedState) -> Result<String, String> {
     let mut state_guard = state.lock().await;
 
     if let Some(pid) = state_guard.miner_child_id {
-        kill_process(pid);
+        kill_process(pid).await;
         state_guard.miner_running = false;
         state_guard.miner_child_id = None;
     }
 
     if let Some(pid) = state_guard.headless_child_id {
-        kill_process(pid);
+        kill_process(pid).await;
         state_guard.headless_running = false;
         state_guard.headless_child_id = None;
     }
 
     if let Some(pid) = state_guard.tx_mining_child_id {
-        kill_process(pid);
+        kill_process(pid).await;
         state_guard.tx_mining_running = false;
         state_guard.tx_mining_child_id = None;
     }
@@ -122,7 +122,7 @@ pub async fn stop_node_internal(state: &SharedState) -> Result<String, String> {
     }
 
     if let Some(pid) = state_guard.node_child_id {
-        kill_process(pid);
+        kill_process(pid).await;
     }
 
     state_guard.node_running = false;

--- a/src-tauri/src/services/tx_mining.rs
+++ b/src-tauri/src/services/tx_mining.rs
@@ -95,7 +95,7 @@ pub async fn stop_tx_mining_internal(state: &SharedState) -> Result<String, Stri
     }
 
     if let Some(pid) = state_guard.tx_mining_child_id {
-        kill_process(pid);
+        kill_process(pid).await;
     }
 
     state_guard.tx_mining_running = false;

--- a/src-tauri/src/tauri_app.rs
+++ b/src-tauri/src/tauri_app.rs
@@ -117,22 +117,22 @@ pub fn run() {
 
                 if let Some(pid) = state.miner_child_id {
                     eprintln!("Cleaning up miner process (PID: {})", pid);
-                    kill_process(pid);
+                    kill_process_sync(pid);
                 }
 
                 if let Some(pid) = state.headless_child_id {
                     eprintln!("Cleaning up wallet-headless process (PID: {})", pid);
-                    kill_process(pid);
+                    kill_process_sync(pid);
                 }
 
                 if let Some(pid) = state.tx_mining_child_id {
                     eprintln!("Cleaning up tx-mining-service process (PID: {})", pid);
-                    kill_process(pid);
+                    kill_process_sync(pid);
                 }
 
                 if let Some(pid) = state.node_child_id {
                     eprintln!("Cleaning up node process (PID: {})", pid);
-                    kill_process(pid);
+                    kill_process_sync(pid);
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Convert `kill_process` in `platform.rs` from sync to async, replacing `std::thread::sleep` with `tokio::time::sleep` so the polling loop (up to 5s) no longer blocks the tokio runtime while holding a `tokio::sync::Mutex`
- Add `.await` at all async call sites in the service modules (`node.rs`, `miner.rs`, `headless.rs`, `tx_mining.rs`)
- Introduce `kill_process_sync` for the synchronous `RunEvent::Exit` cleanup handler in `tauri_app.rs`

Closes #20

## Test plan
- [ ] Verify `cargo check` passes (requires binary stubs)
- [ ] Start and stop each service (node, miner, headless, tx-mining) and confirm processes are terminated correctly
- [ ] Confirm app exit cleanup still kills child processes
- [ ] Verify that stopping a service no longer blocks the UI or other async tasks

🤖 Generated with [AI assistance](https://claude.com/claude-code)