### PR TITLE
Fix race condition in start_node_internal

### DIFF
--- a/src-tauri/src/services/headless.rs
+++ b/src-tauri/src/services/headless.rs
@@ -55,6 +55,12 @@ pub async fn start_headless_internal(
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
     let mut state_guard = state.lock().await;
 
+    // Re-check after re-acquiring the lock to prevent TOCTOU race condition:
+    // another caller may have started wallet-headless while we released the lock.
+    if state_guard.headless_running {
+        return Ok("Wallet-headless is already running".to_string());
+    }
+
     generate_headless_config(&config, &headless_path, txm_url)?;
 
     let entry_point = headless_path.join("dist").join("index.js");

--- a/src-tauri/src/services/miner.rs
+++ b/src-tauri/src/services/miner.rs
@@ -34,6 +34,12 @@ pub async fn start_miner_internal(
 
     let mut state_guard = state.lock().await;
 
+    // Re-check after re-acquiring the lock to prevent TOCTOU race condition:
+    // another caller may have started the miner while we released the lock.
+    if state_guard.miner_running {
+        return Ok("Miner is already running".to_string());
+    }
+
     let binary_path = get_binary_path("cpuminer");
 
     let mut child = TokioCommand::new(&binary_path)

--- a/src-tauri/src/services/node.rs
+++ b/src-tauri/src/services/node.rs
@@ -28,6 +28,12 @@ pub async fn start_node_internal(state: &SharedState) -> Result<String, String> 
 
     let mut state_guard = state.lock().await;
 
+    // Re-check after re-acquiring the lock to prevent TOCTOU race condition:
+    // another caller may have started the node while we released the lock.
+    if state_guard.node_running {
+        return Ok("Node is already running".to_string());
+    }
+
     let binary_path = get_binary_path("hathor-core");
 
     fs::create_dir_all(&config.data_dir)

--- a/src-tauri/src/services/tx_mining.rs
+++ b/src-tauri/src/services/tx_mining.rs
@@ -26,6 +26,12 @@ pub async fn start_tx_mining_internal(state: &SharedState) -> Result<String, Str
 
     let mut state_guard = state.lock().await;
 
+    // Re-check after re-acquiring the lock to prevent TOCTOU race condition:
+    // another caller may have started tx-mining-service while we released the lock.
+    if state_guard.tx_mining_running {
+        return Ok("tx-mining-service is already running".to_string());
+    }
+
     let binary_path = get_binary_path("tx-mining-service");
 
     let internal_dir = binary_path.parent().unwrap().join("_internal");


### PR DESCRIPTION
## Summary

- Fix TOCTOU (time-of-check-time-of-use) race condition in all four service start functions: `start_node_internal`, `start_miner_internal`, `start_headless_internal`, and `start_tx_mining_internal`
- Each function drops the mutex to perform cleanup (killing zombie processes, sleeping), then re-acquires it. A concurrent caller could start the service during this window, resulting in duplicate processes.
- Added a re-check of the `*_running` flag after re-acquiring the lock, so the second caller returns early instead of spawning a duplicate process

## Test plan

- [ ] Verify that concurrent calls to `start_node_internal` only spawn one node process
- [ ] Verify the same for `start_miner_internal`, `start_headless_internal`, and `start_tx_mining_internal`
- [ ] Verify normal start/stop workflows still work correctly
- [ ] Run `cargo fmt` and `cargo check` to confirm no regressions

Closes #19

🤖 Generated with [AI assistance](https://claude.com/claude-code)