### PR TITLE
Add HTTP timeouts and connection pooling to MCP handlers

### DIFF
--- a/src-tauri/src/mcp/handlers.rs
+++ b/src-tauri/src/mcp/handlers.rs
@@ -7,7 +7,7 @@ use super::types::McpState;
 
 /// Execute an MCP tool by name with the given parameters.
 pub async fn execute_tool(state: &McpState, name: &str, params: &Value) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = state.http_client.clone();
     let fullnode_url = state.fullnode_url.read().await.clone();
     let wallet_headless_url = state.wallet_headless_url.read().await.clone();
     let _tx_mining_url = state.tx_mining_url.read().await.clone();
@@ -512,7 +512,7 @@ pub async fn execute_tool(state: &McpState, name: &str, params: &Value) -> Resul
             drop(seeds);
 
             // Try to get faucet balance
-            if let Ok(resp) = reqwest::Client::new()
+            if let Ok(resp) = client
                 .get(format!("{}/v1a/wallet/balance/", fullnode_url))
                 .send()
                 .await

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -61,6 +61,8 @@ pub struct McpState {
     pub fullnode_url: RwLock<String>,
     pub wallet_headless_url: RwLock<String>,
     pub tx_mining_url: RwLock<String>,
+    /// Shared HTTP client with connection pooling and default timeout.
+    pub http_client: reqwest::Client,
 }
 
 impl McpState {
@@ -70,6 +72,12 @@ impl McpState {
         wallet_headless_url: Option<String>,
         tx_mining_url: Option<String>,
     ) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .pool_max_idle_per_host(5)
+            .build()
+            .expect("Failed to build HTTP client");
+
         Self {
             app_state,
             wallet_seeds: Mutex::new(HashMap::new()),
@@ -82,6 +90,7 @@ impl McpState {
             tx_mining_url: RwLock::new(
                 tx_mining_url.unwrap_or_else(|| "http://localhost:8002".to_string()),
             ),
+            http_client,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Create a single `reqwest::Client` in `McpState` with a 30-second default timeout and connection pooling (max 5 idle connections per host)
- Replace all per-request `reqwest::Client::new()` calls in MCP handlers with the shared client
- Prevents MCP tool calls from hanging indefinitely when downstream services (fullnode, wallet-headless) stop responding

Closes #22

## Test plan
- [ ] Verify `cargo check` passes on the `src-tauri` crate
- [ ] Start the MCP server and confirm tools that make HTTP calls (e.g., `get_node_status`, `get_wallet_balance`) still work correctly
- [ ] Confirm that requests time out after ~30s when a target service is unreachable (e.g., stop the fullnode and call `get_node_status`)

🤖 Generated with [AI assistance](https://claude.com/claude-code)