### PR TITLE
Fix nano contract API endpoint paths

### DIFF
--- a/src-tauri/src/commands/nano_contracts.rs
+++ b/src-tauri/src/commands/nano_contracts.rs
@@ -301,7 +301,7 @@ pub(crate) async fn headless_wallet_create_nano_contract(
     let client = reqwest::Client::new();
 
     let response = client
-        .post("http://localhost:8001/wallet/nano-contract/create")
+        .post("http://localhost:8001/wallet/nano-contracts/create")
         .header("X-Wallet-Id", &request.wallet_id)
         .json(&serde_json::json!({
             "blueprint_id": request.blueprint_id,
@@ -336,7 +336,7 @@ pub(crate) async fn headless_wallet_call_nano_contract_method(
     let client = reqwest::Client::new();
 
     let response = client
-        .post("http://localhost:8001/wallet/nano-contract/execute")
+        .post("http://localhost:8001/wallet/nano-contracts/execute")
         .header("X-Wallet-Id", &request.wallet_id)
         .json(&serde_json::json!({
             "nc_id": request.nc_id,


### PR DESCRIPTION
## Summary

- Fixed nano contract API endpoint paths in Tauri commands (`src-tauri/src/commands/nano_contracts.rs`) to use the correct plural form `/wallet/nano-contracts/create` and `/wallet/nano-contracts/execute`, matching the wallet-headless API convention
- The MCP handlers already used the correct plural form; only the Tauri commands needed updating

Closes #23

## Test plan

- [ ] Verify nano contract creation calls succeed against wallet-headless
- [ ] Verify nano contract method execution calls succeed against wallet-headless
- [ ] Confirm MCP nano contract tools still work correctly (no changes needed)

🤖 Generated with [AI assistance](https://claude.com/claude-code)