### PR TITLE
Fix README versions, justfile error handling, and release profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The app provides a clean dashboard with:
 | Component | Technology |
 |-----------|------------|
 | Desktop App | Tauri 2.x (Rust backend, ~10MB) |
-| Frontend | React 18 + TypeScript + Tailwind CSS |
+| Frontend | React 19 + TypeScript + Tailwind CSS 4 |
 | Fullnode | hathor-core (Python, PyInstaller bundle) |
 | Miner | cpuminer (C, SHA256d) |
 | Wallet Service | wallet-headless (Node.js) |
@@ -89,7 +89,7 @@ nix build .#hathor-forge-cli
 
 #### Prerequisites
 
-- Node.js 18+
+- Node.js 22+
 - Rust 1.70+ (for Tauri)
 - Nix (recommended) or manual dependency management
 

--- a/justfile
+++ b/justfile
@@ -52,12 +52,12 @@ test:
 # Format code
 fmt:
     cargo fmt --manifest-path src-tauri/Cargo.toml
-    npm run lint:fix 2>/dev/null || true
+    npm run lint:fix
 
 # Check code
 check:
     cargo check --manifest-path src-tauri/Cargo.toml
-    npm run lint 2>/dev/null || true
+    npm run lint
 
 # Clean build artifacts
 clean:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,3 +44,9 @@ base64 = "0.22"
 miniz_oxide = "0.8"
 ratatui = "0.29"
 crossterm = "0.28"
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1
+opt-level = "s"


### PR DESCRIPTION
## Summary

- **README.md**: Fix incorrect version numbers — React 18 → 19, Tailwind CSS → Tailwind CSS 4, Node.js 18+ → 22+ (matches `flake.nix` which uses `nodejs_22`)
- **justfile**: Remove `2>/dev/null || true` from `check` and `fmt` targets so lint/format errors are actually surfaced to the developer
- **Cargo.toml**: Add `[profile.release]` with LTO, symbol stripping, single codegen unit, and size optimization (`opt-level = "s"`)

**Note:** The justfile `check` and `fmt` targets reference `npm run lint` and `npm run lint:fix`, but these scripts are not defined in `package.json`. They will now fail visibly instead of silently, which is the correct behavior — adding the missing npm scripts should be addressed separately.

Partial fix for #29.

## Test plan

- [ ] Verify README version numbers match `package.json` (React 19) and `flake.nix` (Node.js 22)
- [ ] Run `just check` and `just fmt` — confirm they no longer swallow errors
- [ ] Run `cargo build --release --manifest-path src-tauri/Cargo.toml` and verify the release profile settings take effect (smaller binary with stripped symbols)

🤖 Generated with [AI assistance](https://claude.com/claude-code)