### PR TITLE
Fix frontend dead code, stale state, and unmount cleanup

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,26 +1,15 @@
-import { useState, useRef } from "react";
-import { AlertTriangle, Trash2, Loader2, Power } from "lucide-react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useState } from "react";
+import { AlertTriangle, Trash2, Loader2 } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
+import { useNanoContractStore } from "@/store/useNanoContractStore";
 import * as api from "@/services/tauri";
 
 export function SettingsPage() {
   const { nodeStatus } = useAppStore();
   const [showResetConfirm, setShowResetConfirm] = useState(false);
-  const [showExitConfirm, setShowExitConfirm] = useState(false);
-  const [isShuttingDown, setIsShuttingDown] = useState(false);
-  const isShuttingDownRef = useRef(false);
   const [resetStatus, setResetStatus] = useState<"idle" | "resetting" | "success" | "error">("idle");
   const [resetMessage, setResetMessage] = useState("");
-
-  const handleConfirmExit = async () => {
-    setIsShuttingDown(true);
-    isShuttingDownRef.current = true;
-    try {
-      await api.gracefulShutdown();
-    } catch (_) {}
-    await getCurrentWindow().destroy();
-  };
+  const clearContracts = useNanoContractStore((s) => s.clearContracts);
 
   const handleResetData = async () => {
     if (nodeStatus === "running") {
@@ -31,6 +20,7 @@ export function SettingsPage() {
     setResetStatus("resetting");
     try {
       const result = await api.resetData();
+      clearContracts();
       setResetMessage(result);
       setResetStatus("success");
       setShowResetConfirm(false);
@@ -121,42 +111,6 @@ export function SettingsPage() {
         </div>
       )}
 
-      {/* Exit Confirmation Modal */}
-      {showExitConfirm && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
-          <div className="bg-[#0d1117] border border-slate-800 rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-10 h-10 rounded-full bg-amber-500/20 flex items-center justify-center">
-                <Power className="w-5 h-5 text-amber-400" />
-              </div>
-              <h3 className="text-lg font-semibold text-white">Exit Hathor Forge?</h3>
-            </div>
-            <p className="text-slate-400 mb-6">
-              Are you sure you want to exit? Running services will be stopped gracefully.
-            </p>
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => setShowExitConfirm(false)}
-                disabled={isShuttingDown}
-                className="px-4 py-2 text-slate-400 hover:text-white transition-colors disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleConfirmExit}
-                disabled={isShuttingDown}
-                className="px-4 py-2 bg-amber-500 text-white rounded-lg hover:bg-amber-600 transition-colors disabled:opacity-50 flex items-center gap-2"
-              >
-                {isShuttingDown ? (
-                  <><Loader2 className="w-4 h-4 animate-spin" />Shutting down...</>
-                ) : (
-                  <><Power className="w-4 h-4" />Yes, Exit</>
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import {
   Wallet, Play, Square, Send, Copy, Check, Loader2,
 } from "lucide-react";
@@ -24,6 +25,15 @@ export function WalletPage() {
     expandedWallet, setExpandedWallet,
     copiedAddress, setCopiedAddress,
   } = useWalletStore();
+
+  // Abort controller for cancelling pollWalletStatus on unmount
+  const pollAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      pollAbortRef.current?.abort();
+    };
+  }, []);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -74,11 +84,19 @@ export function WalletPage() {
   };
 
   const pollWalletStatus = async (walletId: string) => {
+    // Cancel any previous polling loop
+    pollAbortRef.current?.abort();
+    const controller = new AbortController();
+    pollAbortRef.current = controller;
+
     const maxAttempts = 30;
     for (let i = 0; i < maxAttempts; i++) {
+      if (controller.signal.aborted) return;
       await new Promise((resolve) => setTimeout(resolve, 1000));
+      if (controller.signal.aborted) return;
       try {
         const status = await api.getHeadlessWalletStatus(walletId);
+        if (controller.signal.aborted) return;
 
         setHeadlessWallets((prev) =>
           prev.map((w) =>

--- a/src/store/useNanoContractStore.ts
+++ b/src/store/useNanoContractStore.ts
@@ -13,6 +13,7 @@ interface NanoContractState {
   addContract: (contract: NanoContract) => void;
   removeContract: (id: string) => void;
   updateContract: (id: string, updates: Partial<NanoContract>) => void;
+  clearContracts: () => void;
 }
 
 export const useNanoContractStore = create<NanoContractState>()(
@@ -35,6 +36,7 @@ export const useNanoContractStore = create<NanoContractState>()(
             c.id === id ? { ...c, ...updates } : c
           ),
         })),
+      clearContracts: () => set({ contracts: [] }),
     }),
     {
       name: 'hathor-forge-nano-contracts',


### PR DESCRIPTION
## Summary

- **Settings page dead code removed**: Deleted the unused `showExitConfirm` state, `isShuttingDownRef` ref, `isShuttingDown` state, `handleConfirmExit` handler, and the exit confirmation modal that was never triggered (`setShowExitConfirm(true)` was never called).
- **Nano contract store cleared on blockchain reset**: Added a `clearContracts` action to `useNanoContractStore` and wired it into the `handleResetData` flow in SettingsPage, so persisted localStorage contracts don't survive a blockchain reset.
- **pollWalletStatus cancellation on unmount**: Wrapped the 30-second polling loop in WalletPage with an `AbortController` that aborts on component unmount, preventing fire-and-forget state updates on an unmounted component.

Partial fix for #26 (code quality items only; wallet send form refactor is out of scope).

## Test plan

- [ ] Open Settings page and verify it renders without errors (no exit modal visible)
- [ ] Reset blockchain data, then check that the Nano Contracts page shows an empty list
- [ ] Create a wallet on WalletPage, then navigate away before it finishes polling — confirm no console warnings about unmounted state updates
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [AI assistance](https://claude.com/claude-code)