### PR TITLE
Add structured logging with tracing crate

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1762,6 +1762,8 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2423,6 +2425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2590,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -3965,6 +3985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,6 +4651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,6 +4985,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5168,6 +5236,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,5 +42,7 @@ bip39 = "2.1"
 getrandom = "0.2"
 base64 = "0.22"
 miniz_oxide = "0.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ratatui = "0.29"
 crossterm = "0.28"

--- a/src-tauri/src/cli_main.rs
+++ b/src-tauri/src/cli_main.rs
@@ -8,6 +8,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tracing::{error, info, warn};
 
 /// Hathor Forge CLI — headless blockchain development environment
 ///
@@ -126,6 +127,14 @@ fn save_settings(path: &PathBuf, settings: &Settings) -> Result<(), String> {
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
     let cli = Cli::parse();
     let sp = settings_path(cli.settings_file.as_ref());
     let saved = load_settings(&sp);
@@ -194,19 +203,13 @@ async fn main() {
             wallet_only: Some(wallet_only),
         };
         match save_settings(&sp, &settings) {
-            Ok(()) => eprintln!("Settings saved to {}", sp.display()),
-            Err(e) => eprintln!("Warning: {}", e),
+            Ok(()) => info!(path = %sp.display(), "Settings saved"),
+            Err(e) => warn!("Failed to save settings: {}", e),
         }
     }
 
     // Print banner
-    eprintln!("╔══════════════════════════════════════════╗");
-    eprintln!(
-        "║         Hathor Forge CLI v{}          ║",
-        env!("CARGO_PKG_VERSION")
-    );
-    eprintln!("╚══════════════════════════════════════════╝");
-    eprintln!();
+    info!("Hathor Forge CLI v{} starting", env!("CARGO_PKG_VERSION"));
 
     let state = Arc::new(Mutex::new(AppState::default()));
 
@@ -214,20 +217,18 @@ async fn main() {
     if fullnode_url.is_some() {
         let mut s = state.lock().await;
         s.node_running = true;
-        eprintln!("  External fullnode: {}", fullnode_url.as_ref().unwrap());
+        info!(service = "node", url = %fullnode_url.as_ref().unwrap(), "Using external fullnode");
     }
 
     // Start services based on flags
     if auto_start || wallet_only {
-        eprintln!("Starting services...");
-        eprintln!();
+        info!("Starting services");
 
         // Start local node (unless external)
         if fullnode_url.is_none() && !wallet_only {
-            eprint!("  Node ............ ");
             match start_node_internal(&state).await {
-                Ok(msg) => eprintln!("{}", msg),
-                Err(e) => eprintln!("ERROR: {}", e),
+                Ok(msg) => info!(service = "node", "{}", msg),
+                Err(e) => error!(service = "node", "Failed to start: {}", e),
             }
             // Wait for node readiness
             tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
@@ -235,26 +236,23 @@ async fn main() {
 
         // Start tx-mining-service (unless external or disabled)
         if tx_mining_url.is_none() && !no_tx_mining && !wallet_only {
-            eprint!("  Tx-Mining ....... ");
             match start_tx_mining_internal(&state).await {
-                Ok(msg) => eprintln!("{}", msg),
-                Err(e) => eprintln!("ERROR: {}", e),
+                Ok(msg) => info!(service = "tx-mining", "{}", msg),
+                Err(e) => error!(service = "tx-mining", "Failed to start: {}", e),
             }
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
 
         // Start miner (unless disabled)
         if !no_miner && !wallet_only {
-            eprint!("  Miner ........... ");
             match start_miner_internal(&state, mining_address).await {
-                Ok(msg) => eprintln!("{}", msg),
-                Err(e) => eprintln!("ERROR: {}", e),
+                Ok(msg) => info!(service = "miner", "{}", msg),
+                Err(e) => error!(service = "miner", "Failed to start: {}", e),
             }
         }
 
         // Start wallet-headless (unless disabled)
         if !no_wallet {
-            eprint!("  Wallet-Headless . ");
             match start_headless_internal(
                 &state,
                 Some(fullnode_url_resolved.as_str()),
@@ -262,21 +260,18 @@ async fn main() {
             )
             .await
             {
-                Ok(msg) => eprintln!("{}", msg),
-                Err(e) => eprintln!("ERROR: {}", e),
+                Ok(msg) => info!(service = "wallet-headless", "{}", msg),
+                Err(e) => error!(service = "wallet-headless", "Failed to start: {}", e),
             }
         }
-
-        eprintln!();
     }
 
     let use_tui = !cli.no_tui && std::io::stdout().is_terminal();
 
     if !use_tui {
         // Headless mode: plain log output
-        eprintln!("  MCP Server ...... http://127.0.0.1:{}", mcp_port);
-        eprintln!();
-        eprintln!("Press Ctrl+C to stop all services and exit.");
+        info!(service = "mcp", port = mcp_port, "MCP server available at http://127.0.0.1:{}", mcp_port);
+        info!("Press Ctrl+C to stop all services and exit");
     }
 
     let shutdown_state = state.clone();
@@ -295,12 +290,9 @@ async fn main() {
         {
             let msg = e.to_string();
             if msg.contains("Address already in use") {
-                eprintln!();
-                eprintln!("ERROR: Port {} is already in use.", mcp_port);
-                eprintln!("  Another hathor-forge instance may be running.");
-                eprintln!("  Use --mcp-port <PORT> to pick a different port.");
+                error!(service = "mcp", port = mcp_port, "Port {} is already in use. Another hathor-forge instance may be running. Use --mcp-port <PORT> to pick a different port.", mcp_port);
             } else {
-                eprintln!("MCP server error: {}", e);
+                error!(service = "mcp", "MCP server error: {}", e);
             }
         }
     });
@@ -313,28 +305,27 @@ async fn main() {
         if let Err(e) =
             hathor_forge_lib::tui::run_tui(tui_state, mcp_port, fn_url, wh_url, tm_url).await
         {
-            eprintln!("TUI error: {}", e);
+            error!("TUI error: {}", e);
         }
-        eprintln!("Shutting down...");
+        info!("Shutting down");
     } else {
         // Headless mode: wait for Ctrl+C
         let ctrl_c = tokio::signal::ctrl_c();
         tokio::select! {
             _ = ctrl_c => {
-                eprintln!();
-                eprintln!("Shutting down...");
+                info!("Received Ctrl+C, shutting down");
             }
             _ = mcp_handle => {
-                eprintln!("MCP server stopped unexpectedly.");
+                warn!(service = "mcp", "MCP server stopped unexpectedly");
             }
         }
     }
 
     // Graceful shutdown
     match stop_node_internal(&shutdown_state).await {
-        Ok(msg) => eprintln!("  {}", msg),
-        Err(e) => eprintln!("  Shutdown error: {}", e),
+        Ok(msg) => info!(service = "node", "{}", msg),
+        Err(e) => error!("Shutdown error: {}", e),
     }
 
-    eprintln!("Done.");
+    info!("Shutdown complete");
 }

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -13,6 +13,7 @@ use axum::{
     Router,
 };
 use std::sync::Arc;
+use tracing::info;
 
 pub use types::{McpSharedState, McpState};
 
@@ -50,7 +51,7 @@ pub async fn start_mcp_server(
     let app = create_mcp_router(app_state, fullnode_url, wallet_headless_url, tx_mining_url);
 
     let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port)).await?;
-    eprintln!("MCP Server listening on http://127.0.0.1:{}", port);
+    info!(service = "mcp", port = port, "MCP server listening on http://127.0.0.1:{}", port);
 
     axum::serve(listener, app).await?;
 

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 use tokio::process::Command as TokioCommand;
+use tracing::warn;
 
 use crate::config::HeadlessConfig;
 
@@ -189,10 +190,7 @@ pub async fn kill_process(pid: u32) {
                 return;
             }
         }
-        eprintln!(
-            "Process {} did not exit after SIGTERM, sending SIGKILL",
-            pid
-        );
+        warn!(pid = pid, "Process did not exit after SIGTERM, sending SIGKILL");
         let _ = Command::new("kill")
             .args(["-KILL", &pid.to_string()])
             .output();
@@ -226,10 +224,7 @@ pub fn kill_process_sync(pid: u32) {
                 return;
             }
         }
-        eprintln!(
-            "Process {} did not exit after SIGTERM, sending SIGKILL",
-            pid
-        );
+        warn!(pid = pid, "Process did not exit after SIGTERM, sending SIGKILL");
         let _ = Command::new("kill")
             .args(["-KILL", &pid.to_string()])
             .output();

--- a/src-tauri/src/tauri_app.rs
+++ b/src-tauri/src/tauri_app.rs
@@ -3,9 +3,16 @@ use super::*;
 use std::sync::Arc;
 use tauri::Manager;
 use tokio::sync::Mutex;
+use tracing::{error, info};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
     let state = Arc::new(Mutex::new(AppState::default())) as SharedState;
     let cleanup_state = state.clone();
     let mcp_state = state.clone();
@@ -97,7 +104,7 @@ pub fn run() {
                 if let Err(e) =
                     mcp::start_mcp_server(mcp_state, MCP_SERVER_PORT, None, None, None).await
                 {
-                    eprintln!("Failed to start MCP server: {}", e);
+                    error!(service = "mcp", port = MCP_SERVER_PORT, "Failed to start MCP server: {}", e);
                 }
             });
             Ok(())
@@ -116,22 +123,22 @@ pub fn run() {
                 let state = cleanup_state.blocking_lock();
 
                 if let Some(pid) = state.miner_child_id {
-                    eprintln!("Cleaning up miner process (PID: {})", pid);
+                    info!(service = "miner", pid = pid, "Cleaning up miner process");
                     kill_process_sync(pid);
                 }
 
                 if let Some(pid) = state.headless_child_id {
-                    eprintln!("Cleaning up wallet-headless process (PID: {})", pid);
+                    info!(service = "wallet-headless", pid = pid, "Cleaning up wallet-headless process");
                     kill_process_sync(pid);
                 }
 
                 if let Some(pid) = state.tx_mining_child_id {
-                    eprintln!("Cleaning up tx-mining-service process (PID: {})", pid);
+                    info!(service = "tx-mining", pid = pid, "Cleaning up tx-mining-service process");
                     kill_process_sync(pid);
                 }
 
                 if let Some(pid) = state.node_child_id {
-                    eprintln!("Cleaning up node process (PID: {})", pid);
+                    info!(service = "node", pid = pid, "Cleaning up node process");
                     kill_process_sync(pid);
                 }
             }


### PR DESCRIPTION
## Summary
- Replace all `eprintln!` calls (~20 occurrences) with `tracing` macros (`info!`, `error!`, `warn!`) across `platform.rs`, `tauri_app.rs`, `cli_main.rs`, and `mcp/mod.rs`
- Add `tracing` and `tracing-subscriber` (with `env-filter` feature) as dependencies
- Initialize `tracing-subscriber` with `RUST_LOG` env filter support in both the Tauri GUI and CLI entry points
- Add structured fields (`service`, `pid`, `port`) to log events for better observability

## Test plan
- [ ] Run `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --lib` to verify library compiles
- [ ] Run `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --bin hathor-forge-cli` to verify CLI compiles
- [ ] Start the CLI with `RUST_LOG=debug` and verify structured log output appears on stderr
- [ ] Start the CLI with default settings and verify info-level messages appear
- [ ] Verify `RUST_LOG=warn` suppresses info-level output

Closes #24

🤖 Generated with [AI assistance](https://claude.com/claude-code)