### PR TITLE
Bundle Node.js binary for wallet-headless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build explorer
         run: nix develop --command bash ./scripts/build-explorer.sh
 
+      - name: Download Node.js binary
+        run: bash ./scripts/build-node.sh
+
       - name: Install npm dependencies
         run: nix develop --command npm ci
 
@@ -98,6 +101,9 @@ jobs:
 
       - name: Build explorer
         run: nix develop --command bash ./scripts/build-explorer.sh
+
+      - name: Download Node.js binary
+        run: bash ./scripts/build-node.sh
 
       - name: Install npm dependencies
         run: nix develop --command npm ci

--- a/flake.nix
+++ b/flake.nix
@@ -204,6 +204,13 @@
               ./scripts/build-tx-mining-service.sh
             '');
           };
+          build-node = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "build-node" ''
+              cd ${toString ./.}
+              ./scripts/build-node.sh
+            '');
+          };
         };
 
         devShells.default = pkgs.mkShell {
@@ -280,6 +287,7 @@
             echo "  build-explorer        - Build hathor-explorer for embedding"
             echo "  build-wallet-headless - Build wallet-headless for multi-wallet support"
             echo "  build-tx-mining-service - Build tx-mining-service for transaction mining"
+            echo "  build-node            - Download Node.js binary for bundling"
             echo "  build-linux           - Build Linux binaries using Docker (cross-platform)"
             echo ""
 

--- a/scripts/bin/build-node
+++ b/scripts/bin/build-node
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")/.." && ./build-node.sh

--- a/scripts/build-node.sh
+++ b/scripts/build-node.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Download Node.js binary for bundling with the app
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="$PROJECT_DIR/src-tauri/binaries"
+
+# Node.js version to bundle
+NODE_VERSION="${NODE_VERSION:-22.14.0}"
+
+echo "=== Downloading Node.js $NODE_VERSION binary ==="
+
+# Detect platform
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+    Darwin)
+        NODE_OS="darwin"
+        if [[ "$ARCH" == "arm64" ]]; then
+            TARGET="aarch64-apple-darwin"
+            NODE_ARCH="arm64"
+        else
+            TARGET="x86_64-apple-darwin"
+            NODE_ARCH="x64"
+        fi
+        ;;
+    Linux)
+        NODE_OS="linux"
+        if [[ "$ARCH" == "aarch64" ]]; then
+            TARGET="aarch64-unknown-linux-gnu"
+            NODE_ARCH="arm64"
+        else
+            TARGET="x86_64-unknown-linux-gnu"
+            NODE_ARCH="x64"
+        fi
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        NODE_OS="win"
+        TARGET="x86_64-pc-windows-msvc"
+        NODE_ARCH="x64"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+echo "Platform: $NODE_OS-$NODE_ARCH"
+echo "Target:   $TARGET"
+echo "Output:   $OUTPUT_DIR"
+echo ""
+
+mkdir -p "$OUTPUT_DIR"
+
+DOWNLOAD_DIR="$PROJECT_DIR/build/node"
+rm -rf "$DOWNLOAD_DIR"
+mkdir -p "$DOWNLOAD_DIR"
+
+if [[ "$NODE_OS" == "win" ]]; then
+    ARCHIVE="node-v${NODE_VERSION}-${NODE_OS}-${NODE_ARCH}.zip"
+    URL="https://nodejs.org/dist/v${NODE_VERSION}/${ARCHIVE}"
+    echo "Downloading $URL ..."
+    curl -fsSL "$URL" -o "$DOWNLOAD_DIR/$ARCHIVE"
+    unzip -q "$DOWNLOAD_DIR/$ARCHIVE" -d "$DOWNLOAD_DIR"
+    cp "$DOWNLOAD_DIR/node-v${NODE_VERSION}-${NODE_OS}-${NODE_ARCH}/node.exe" \
+       "$OUTPUT_DIR/node-${TARGET}.exe"
+    echo "Binary: $OUTPUT_DIR/node-${TARGET}.exe"
+else
+    ARCHIVE="node-v${NODE_VERSION}-${NODE_OS}-${NODE_ARCH}.tar.gz"
+    URL="https://nodejs.org/dist/v${NODE_VERSION}/${ARCHIVE}"
+    echo "Downloading $URL ..."
+    curl -fsSL "$URL" -o "$DOWNLOAD_DIR/$ARCHIVE"
+    tar -xzf "$DOWNLOAD_DIR/$ARCHIVE" -C "$DOWNLOAD_DIR"
+    cp "$DOWNLOAD_DIR/node-v${NODE_VERSION}-${NODE_OS}-${NODE_ARCH}/bin/node" \
+       "$OUTPUT_DIR/node-${TARGET}"
+    chmod +x "$OUTPUT_DIR/node-${TARGET}"
+    echo "Binary: $OUTPUT_DIR/node-${TARGET}"
+fi
+
+# Clean up
+rm -rf "$DOWNLOAD_DIR"
+
+echo ""
+echo "=== Download complete ==="
+echo ""
+echo "Test with:"
+echo "  $OUTPUT_DIR/node-${TARGET} --version"

--- a/src-tauri/src/commands/headless.rs
+++ b/src-tauri/src/commands/headless.rs
@@ -38,11 +38,12 @@ pub(crate) async fn start_headless(
     generate_headless_config(&config, &headless_path, "http://localhost:8002")?;
 
     // Find node binary to run with
+    let node_bin = get_node_binary_path()?;
     let entry_point = headless_path.join("dist").join("index.js");
     let working_dir = headless_path.join("dist");
 
-    // Spawn the process using node (working dir must be dist/ where config.js is)
-    let mut child = TokioCommand::new("node")
+    // Spawn the process using bundled node (working dir must be dist/ where config.js is)
+    let mut child = TokioCommand::new(&node_bin)
         .args([entry_point.to_string_lossy().as_ref()])
         .current_dir(&working_dir)
         .stdin(Stdio::null())

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -72,6 +72,63 @@ pub fn set_library_path_env(cmd: &mut TokioCommand, internal_dir: &std::path::Pa
     let _ = (cmd, internal_dir);
 }
 
+/// Get the path to the bundled Node.js binary.
+///
+/// In production builds the binary is expected at
+/// `src-tauri/binaries/node-{target-triple}` (or `.exe` on Windows).
+/// During development, if no bundled binary is found we fall back to
+/// the bare `node` command so the system PATH is used instead.
+pub fn get_node_binary_path() -> Result<PathBuf, String> {
+    let target = if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            "aarch64-apple-darwin"
+        } else {
+            "x86_64-apple-darwin"
+        }
+    } else if cfg!(target_os = "linux") {
+        if cfg!(target_arch = "aarch64") {
+            "aarch64-unknown-linux-gnu"
+        } else {
+            "x86_64-unknown-linux-gnu"
+        }
+    } else {
+        "x86_64-pc-windows-msvc"
+    };
+
+    let exe_suffix = if cfg!(target_os = "windows") {
+        ".exe"
+    } else {
+        ""
+    };
+
+    let binaries_dir = match std::env::var("HATHOR_FORGE_BINARIES_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("binaries"),
+    };
+
+    // Try target-triple suffixed binary first
+    let target_path = binaries_dir.join(format!("node-{}{}", target, exe_suffix));
+    if target_path.exists() {
+        return Ok(target_path);
+    }
+
+    // Try bare name
+    let bare_path = binaries_dir.join(format!("node{}", exe_suffix));
+    if bare_path.exists() {
+        return Ok(bare_path);
+    }
+
+    // Dev fallback: use node from PATH
+    if cfg!(debug_assertions) {
+        return Ok(PathBuf::from("node"));
+    }
+
+    Err(format!(
+        "Bundled Node.js binary not found. Looked for {:?} and {:?}",
+        target_path, bare_path
+    ))
+}
+
 /// Get the path to the wallet-headless-dist directory
 pub fn get_headless_dist_path() -> PathBuf {
     if let Ok(dir) = std::env::var("HATHOR_FORGE_HEADLESS_DIR") {

--- a/src-tauri/src/services/headless.rs
+++ b/src-tauri/src/services/headless.rs
@@ -3,8 +3,8 @@ use tokio::process::Command as TokioCommand;
 
 use crate::config::HeadlessConfig;
 use crate::platform::{
-    detect_network_from_url, generate_headless_config, get_headless_dist_path, kill_process,
-    kill_process_on_port,
+    detect_network_from_url, generate_headless_config, get_headless_dist_path,
+    get_node_binary_path, kill_process, kill_process_on_port,
 };
 use crate::state::{spawn_log_reader, SharedState};
 
@@ -63,10 +63,11 @@ pub async fn start_headless_internal(
 
     generate_headless_config(&config, &headless_path, txm_url)?;
 
+    let node_bin = get_node_binary_path()?;
     let entry_point = headless_path.join("dist").join("index.js");
     let working_dir = headless_path.join("dist");
 
-    let mut child = TokioCommand::new("node")
+    let mut child = TokioCommand::new(&node_bin)
         .args([entry_point.to_string_lossy().as_ref()])
         .current_dir(&working_dir)
         .stdin(Stdio::null())


### PR DESCRIPTION
## Summary
- Add `get_node_binary_path()` to `platform.rs` that locates a bundled Node.js binary using the same target-triple pattern as other binaries (falls back to PATH `node` in dev builds)
- Replace both `TokioCommand::new("node")` calls in `services/headless.rs` and `commands/headless.rs` with the bundled binary path
- Add `scripts/build-node.sh` to download the official Node.js binary for the current platform into `src-tauri/binaries/node-{target-triple}`
- Update CI workflows and `flake.nix` with the new `build-node` step

Closes #25

## Test plan
- [ ] Run `build-node` to download the Node.js binary
- [ ] Run `build-wallet-headless` then start wallet-headless; verify it uses the bundled node
- [ ] Verify dev mode still works with PATH fallback (no bundled binary needed)
- [ ] Verify CI builds pass on Linux and macOS

🤖 Generated with [AI assistance](https://claude.com/claude-code)