### PR TITLE
Add error dismiss, escape-to-close, unread badge, and state reconciliation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useAppStore } from "./store/useAppStore";
 import { useNodeStatusPolling } from "@/hooks/useNodeStatus";
 import { useContractStatesPolling } from "@/hooks/useContractStates";
 import { useTauriEvents } from "@/hooks/useTauriEvents";
+import { useInitialStateReconciliation } from "@/hooks/useInitialStateReconciliation";
 
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
@@ -19,8 +20,9 @@ import { ApiExplorerPage } from "@/pages/ApiExplorerPage";
 function App() {
   const currentPage = useAppStore((s) => s.currentPage);
 
-  // Global hooks: polling & event subscriptions
+  // Global hooks: polling, event subscriptions & initial state
   useTauriEvents();
+  useInitialStateReconciliation();
   useNodeStatusPolling();
   useContractStatesPolling();
 

--- a/src/components/layout/ErrorBanner.tsx
+++ b/src/components/layout/ErrorBanner.tsx
@@ -1,13 +1,22 @@
+import { X } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
 
 export function ErrorBanner() {
   const error = useAppStore((s) => s.error);
+  const setError = useAppStore((s) => s.setError);
 
   if (!error) return null;
 
   return (
-    <div className="bg-rose-500/10 border-b border-rose-500/30 px-6 py-3">
+    <div className="bg-rose-500/10 border-b border-rose-500/30 px-6 py-3 flex items-center justify-between">
       <p className="text-sm text-rose-400 font-medium">{error}</p>
+      <button
+        onClick={() => setError(null)}
+        className="p-1 rounded hover:bg-rose-500/20 transition-colors text-rose-400 hover:text-rose-300"
+        aria-label="Dismiss error"
+      >
+        <X className="w-4 h-4" />
+      </button>
     </div>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,7 +15,7 @@ const navItems: { icon: typeof Activity; label: string; page: PageType }[] = [
 ];
 
 export function Sidebar() {
-  const { currentPage, setCurrentPage, logs } = useAppStore();
+  const { currentPage, setCurrentPage, unreadLogCount } = useAppStore();
 
   return (
     <aside className="w-72 border-r border-slate-800/50 bg-[#0d1117] flex flex-col">
@@ -44,9 +44,9 @@ export function Sidebar() {
           >
             <item.icon className="h-4 w-4" />
             {item.label}
-            {item.page === "logs" && logs.length > 0 && (
-              <span className="ml-auto px-1.5 py-0.5 rounded text-[10px] font-bold bg-slate-700 text-slate-300">
-                {logs.length}
+            {item.page === "logs" && unreadLogCount > 0 && (
+              <span className="ml-auto px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-500/20 text-amber-400">
+                {unreadLogCount}
               </span>
             )}
           </button>

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+/**
+ * Calls `handler` when the Escape key is pressed, but only while `active` is true.
+ */
+export function useEscapeKey(handler: () => void, active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handler();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [handler, active]);
+}

--- a/src/hooks/useInitialStateReconciliation.ts
+++ b/src/hooks/useInitialStateReconciliation.ts
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import * as api from "@/services/tauri";
+import { useAppStore } from "@/store/useAppStore";
+import { useWalletStore } from "@/store/useWalletStore";
+
+/**
+ * On app launch, check the actual status of managed services
+ * instead of assuming everything is stopped.
+ */
+export function useInitialStateReconciliation() {
+  const setNodeStatus = useAppStore((s) => s.setNodeStatus);
+  const setMinerStatus = useAppStore((s) => s.setMinerStatus);
+  const setBlockHeight = useAppStore((s) => s.setBlockHeight);
+  const setHeadlessStatus = useWalletStore((s) => s.setHeadlessStatus);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function reconcile() {
+      // Check node status
+      try {
+        const nodeStatus = await api.getNodeStatus();
+        if (cancelled) return;
+        if (nodeStatus.running) {
+          setNodeStatus("running");
+          if (nodeStatus.block_height !== null) {
+            setBlockHeight(nodeStatus.block_height);
+          }
+        }
+      } catch {
+        // Node status check failed — leave as stopped
+      }
+
+      // Check miner status
+      try {
+        const minerStatus = await api.getMinerStatus();
+        if (cancelled) return;
+        if (minerStatus.running) {
+          setMinerStatus("mining");
+        }
+      } catch {
+        // Miner status check failed — leave as stopped
+      }
+
+      // Check headless status
+      try {
+        const headlessStatus = await api.getHeadlessStatus();
+        if (cancelled) return;
+        if (headlessStatus.running) {
+          setHeadlessStatus(headlessStatus);
+        }
+      } catch {
+        // Headless status check failed — leave as stopped
+      }
+    }
+
+    reconcile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [setNodeStatus, setMinerStatus, setBlockHeight, setHeadlessStatus]);
+}

--- a/src/pages/LogsPage.tsx
+++ b/src/pages/LogsPage.tsx
@@ -21,10 +21,15 @@ function getSourceStyle(source: LogSource) {
 }
 
 export function LogsPage() {
-  const { logs, logFilters, clearLogs, toggleLogFilter } = useAppStore();
+  const { logs, logFilters, clearLogs, toggleLogFilter, markLogsRead } = useAppStore();
   const logsEndRef = useRef<HTMLDivElement>(null);
 
   const filteredLogs = logs.filter((log) => logFilters.has(log.source));
+
+  // Mark logs as read whenever this page is mounted or new logs arrive
+  useEffect(() => {
+    markLogsRead();
+  }, [logs, markLogsRead]);
 
   useEffect(() => {
     logsEndRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/src/pages/NanoContractsPage.tsx
+++ b/src/pages/NanoContractsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import {
   Zap, Plus, Search, Copy, Clock, FileCode, RefreshCw,
   Trash2, Loader2, Play, Square,
@@ -7,6 +7,7 @@ import { useAppStore } from "@/store/useAppStore";
 import { useWalletStore } from "@/store/useWalletStore";
 import { useNanoContractStore } from "@/store/useNanoContractStore";
 import { useBlueprints } from "@/hooks/useBlueprints";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 import * as api from "@/services/tauri";
 
 export function NanoContractsPage() {
@@ -32,6 +33,27 @@ export function NanoContractsPage() {
   const [selectedWalletForInteract, setSelectedWalletForInteract] = useState("");
   const [isInitializing, setIsInitializing] = useState(false);
   const [isSubmittingMethod, setIsSubmittingMethod] = useState(false);
+
+  // ── Escape-to-close modals ────────────────────────────────────────────────
+  const closeRegisterModal = useCallback(() => {
+    setShowRegisterContract(false);
+    setRegisterContractId("");
+  }, []);
+  const closeInitWizard = useCallback(() => {
+    setShowInitWizard(false);
+    setSelectedBlueprint(null);
+  }, []);
+  const closeInteractionModal = useCallback(() => {
+    setSelectedContractForInteract(null);
+  }, []);
+
+  const anyModalOpen = showRegisterContract || showInitWizard || !!selectedContractForInteract;
+  const escapeHandler = useCallback(() => {
+    if (selectedContractForInteract) closeInteractionModal();
+    else if (showInitWizard) closeInitWizard();
+    else if (showRegisterContract) closeRegisterModal();
+  }, [selectedContractForInteract, showInitWizard, showRegisterContract, closeInteractionModal, closeInitWizard, closeRegisterModal]);
+  useEscapeKey(escapeHandler, anyModalOpen);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { AlertTriangle, Trash2, Loader2 } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
 import { useNanoContractStore } from "@/store/useNanoContractStore";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 import * as api from "@/services/tauri";
 
 export function SettingsPage() {
@@ -10,6 +11,9 @@ export function SettingsPage() {
   const [resetStatus, setResetStatus] = useState<"idle" | "resetting" | "success" | "error">("idle");
   const [resetMessage, setResetMessage] = useState("");
   const clearContracts = useNanoContractStore((s) => s.clearContracts);
+
+  const closeResetModal = useCallback(() => setShowResetConfirm(false), []);
+  useEscapeKey(closeResetModal, showResetConfirm);
 
   const handleResetData = async () => {
     if (nodeStatus === "running") {

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import {
   Wallet, Play, Square, Send, Copy, Check, Loader2,
 } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
 import { useWalletStore } from "@/store/useWalletStore";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 import * as api from "@/services/tauri";
 import type { HeadlessWallet } from "@/types";
 
@@ -25,6 +26,14 @@ export function WalletPage() {
     expandedWallet, setExpandedWallet,
     copiedAddress, setCopiedAddress,
   } = useWalletStore();
+
+  const closeCreateWalletModal = useCallback(() => {
+    setShowCreateWallet(false);
+    setNewSeed(null);
+    setNewWalletId("");
+    setImportSeed("");
+  }, [setShowCreateWallet, setNewSeed, setNewWalletId, setImportSeed]);
+  useEscapeKey(closeCreateWalletModal, showCreateWallet);
 
   // Abort controller for cancelling pollWalletStatus on unmount
   const pollAbortRef = useRef<AbortController | null>(null);

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -32,8 +32,10 @@ interface AppState {
   logs: LogEntry[];
   logFilters: Set<LogSource>;
   _logIdCounter: number;
+  unreadLogCount: number;
   addLog: (source: LogSource, message: string) => void;
   clearLogs: () => void;
+  markLogsRead: () => void;
   toggleLogFilter: (source: LogSource) => void;
 }
 
@@ -60,6 +62,7 @@ export const useAppStore = create<AppState>()((set, get) => ({
   logs: [],
   logFilters: new Set<LogSource>(["node", "miner", "headless"]),
   _logIdCounter: 0,
+  unreadLogCount: 0,
   addLog: (source, message) => {
     const cleanMessage = stripAnsi(message);
     if (!cleanMessage.trim()) return;
@@ -75,9 +78,11 @@ export const useAppStore = create<AppState>()((set, get) => ({
     set({
       logs: [...state.logs.slice(-MAX_LOG_ENTRIES), entry],
       _logIdCounter: state._logIdCounter + 1,
+      unreadLogCount: state.unreadLogCount + 1,
     });
   },
-  clearLogs: () => set({ logs: [] }),
+  clearLogs: () => set({ logs: [], unreadLogCount: 0 }),
+  markLogsRead: () => set({ unreadLogCount: 0 }),
   toggleLogFilter: (source) => {
     const filters = new Set(get().logFilters);
     if (filters.has(source)) {


### PR DESCRIPTION
## Summary
- **ErrorBanner dismiss**: Added an X/close button to the error banner so users can dismiss it
- **Escape-to-close modals**: Added a reusable `useEscapeKey` hook and wired it into all modal-containing pages (WalletPage, NanoContractsPage, SettingsPage)
- **Unread log badge**: Sidebar log badge now shows unread count instead of total log count; resets when the user views the Logs page
- **Initial state reconciliation**: On app launch, queries actual service statuses (node, miner, headless) via their status endpoints instead of assuming everything is stopped

Closes #27

## Test plan
- [ ] Trigger an error (e.g., start miner without node) and verify the X button dismisses the banner
- [ ] Open any modal (Create Wallet, Register Contract, Reset Data, etc.) and press Escape to close it
- [ ] Start the node and miner, verify the sidebar log badge increments; navigate to Logs page and confirm the badge resets to 0
- [ ] With services running, reload the app window and verify the dashboard reflects the correct running states

🤖 Generated with [AI assistance](https://claude.com/claude-code)